### PR TITLE
[fix] Update internal proxies IPs (OpenShift 4)

### DIFF
--- a/roles/ticketshop-openshift/templates/ticketshop-apache-conf.j2
+++ b/roles/ticketshop-openshift/templates/ticketshop-apache-conf.j2
@@ -7,7 +7,7 @@ LogFormat "%T %D %V %a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"
 CustomLog /dev/stdout camptocamp
 
 RemoteIPHeader X-Forwarded-For
-RemoteIPInternalProxy 172.31.0.0/16 10.180.21.231 10.180.21.232 10.180.21.233 10.180.21.244
+RemoteIPInternalProxy 128.178.211.0/24 10.20.0.0/16
 
 <VirtualHost *:8080>
   ServerName {{ ticketshop_hostname }}


### PR DESCRIPTION
**Description**

This fix restores the real client IP (in `REMOTE_ADDR`) by correctly handling reverse proxy headers, and then the errors 500 on POST to `/cgi-bin/artifactServer" due to IP access restriction (IP access not allowed..).

-- After the hotfix in green:

![Selection_110](https://github.com/user-attachments/assets/42782d7d-1079-41c7-8e10-7d357ee219da)

