### PR TITLE
[feature] Reduce CPU + memory resources

### DIFF
--- a/roles/ticketshop-openshift/tasks/app.yml
+++ b/roles/ticketshop-openshift/tasks/app.yml
@@ -140,10 +140,10 @@
                   - containerPort: 8080
                 resources:
                   requests:
-                    cpu: "500m"
+                    cpu: "200m"
                     memory: "1Gi"
                   limits:
-                    cpu: "1"
+                    cpu: "400m"
                     memory: "1Gi"
                 envFrom:
                   - configMapRef:

--- a/roles/ticketshop-openshift/tasks/app.yml
+++ b/roles/ticketshop-openshift/tasks/app.yml
@@ -141,7 +141,7 @@
                 resources:
                   requests:
                     cpu: "200m"
-                    memory: "1Gi"
+                    memory: "512Mi"
                   limits:
                     cpu: "400m"
                     memory: "1Gi"


### PR DESCRIPTION
Since OpenShift licenses are based on CPU usage, we need to set appropriate values. 
These values are based on the metrics from the last two weeks.